### PR TITLE
Fix display bugs when set image

### DIFF
--- a/SVPulsingAnnotationView/SVPulsingAnnotationView.m
+++ b/SVPulsingAnnotationView/SVPulsingAnnotationView.m
@@ -138,7 +138,7 @@
     if(self.superview)
         [self rebuildLayers];
     
-    self.imageView.image = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+    self.imageView.image = image;
     self.imageView.bounds = CGRectMake(0, 0, ceil(image.size.width), ceil(image.size.height));
     self.imageView.center = CGPointMake(self.bounds.size.width/2, self.bounds.size.height/2);
     self.imageView.tintColor = self.annotationColor;


### PR DESCRIPTION

![screen shot 2014-05-10 at 1 00 58 am](https://cloud.githubusercontent.com/assets/1638935/2929575/c1242b98-d78a-11e3-9824-a143eda85784.png)
When set an image in SVPulsingAnnotationView, it will only showing color block.