### PR TITLE
Allows fix for issue #19 where Images set are always Template.

### DIFF
--- a/SVPulsingAnnotationView/SVPulsingAnnotationView.h
+++ b/SVPulsingAnnotationView/SVPulsingAnnotationView.h
@@ -14,6 +14,7 @@
 @property (nonatomic, strong) UIColor *pulseColor; // default is same as annotationColor
 @property (nonatomic, strong) UIImage *image; // default is nil
 @property (nonatomic, strong) UIImage *headingImage; // default is nil
+@property (nonatomic, assign) BOOL setImagesAsTemplate; // default is YES
 
 @property (nonatomic, readwrite) float pulseScaleFactor; // default is 5.3
 @property (nonatomic, readwrite) NSTimeInterval pulseAnimationDuration; // default is 1s

--- a/SVPulsingAnnotationView/SVPulsingAnnotationView.m
+++ b/SVPulsingAnnotationView/SVPulsingAnnotationView.m
@@ -46,6 +46,7 @@
         self.delayBetweenPulseCycles = 0;
         self.annotationColor = [UIColor colorWithRed:0.000 green:0.478 blue:1.000 alpha:1];
         self.outerColor = [UIColor whiteColor];
+        self.setImagesAsTemplate = YES;
         
         self.willMoveToSuperviewAnimationBlock = ^(SVPulsingAnnotationView *annotationView, UIView *superview) {
             CAKeyframeAnimation *bounceAnimation = [CAKeyframeAnimation animationWithKeyPath:@"transform.scale"];
@@ -149,7 +150,7 @@
     if(self.superview)
         [self rebuildLayers];
     
-    self.imageView.image = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+    self.imageView.image = self.setImagesAsTemplate ? [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate] : image;
     self.imageView.bounds = CGRectMake(0, 0, ceil(image.size.width), ceil(image.size.height));
     self.imageView.center = CGPointMake(self.bounds.size.width/2, self.bounds.size.height/2);
     self.imageView.tintColor = self.annotationColor;
@@ -162,7 +163,7 @@
         [self rebuildLayers];
     }
     
-    self.headingImageView.image = [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+    self.headingImageView.image = self.setImagesAsTemplate ? [image imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate] : image;
     self.headingImageView.bounds = CGRectMake(0, 0, ceil(image.size.width), ceil(image.size.height));
     self.headingImageView.center = CGPointMake(self.bounds.size.width/2, self.bounds.size.height/2);
     self.headingImageView.tintColor = self.annotationColor;


### PR DESCRIPTION
Basically a fix for #19 **(Request: Allow non-template Images or Access to the ImageView in some way)** which allows for an Boolean value, `setImagesAsTemplate`, to be set on the `SVPulsingAnnotationView` which determines whether images added to the `imageView` and `headingImageView` are to be the exact image that you give it, or rendered as Template images. Without this fix, any images given to these Image Views are set with the `UIImageRenderingModeAlwaysTemplate` Rendering Mode.

This fix is much better than the subclass "hack" seen in issue #19, with only 4 line changes compared to having to subclass, override two methods, and access the private `imageView` property through searching the subviews.

The changes don't break anything in the master branch and the new Boolean defaults to YES as to not change anything for those who would update to this commit and still want the Rendering Mode defaulting to Template.