### PR TITLE
Add a `didRebuildLayersBlock` property to be notified of hierarchy changes

### DIFF
--- a/SVPulsingAnnotationView/SVPulsingAnnotationView.h
+++ b/SVPulsingAnnotationView/SVPulsingAnnotationView.h
@@ -25,5 +25,6 @@
 @property (nonatomic, readwrite) NSTimeInterval delayBetweenPulseCycles; // default is 1s
 
 @property (nonatomic, copy) void (^willMoveToSuperviewAnimationBlock)(SVPulsingAnnotationView *view, UIView *superview); // default is pop animation
+@property (nonatomic, copy) void (^didRebuildLayersBlock)(SVPulsingAnnotationView *view);
 
 @end

--- a/SVPulsingAnnotationView/SVPulsingAnnotationView.m
+++ b/SVPulsingAnnotationView/SVPulsingAnnotationView.m
@@ -86,6 +86,10 @@
             [self addSubview:self.imageView];
         else
             [self.layer addSublayer:self.colorDotLayer];
+        
+        if (self.didRebuildLayersBlock) {
+            self.didRebuildLayersBlock(self);
+        }
     };
     
     if (@available(iOS 13.0, *)) {


### PR DESCRIPTION
Add a property `didRebuildLayersBlock` than can be used to be notified after the SVPulsingAnnotationView has completely rebuilt its layers & views hierarchy. 

This can be useful to react to these changes, particularly for a subclass of `SVPulsingAnnotationView`.